### PR TITLE
Make callback.py Python 3 compatible

### DIFF
--- a/spy/heraspy/callback.py
+++ b/spy/heraspy/callback.py
@@ -2,6 +2,7 @@ from keras.callbacks import Callback
 import json
 import numpy as np
 import requests
+from functools import reduce
 
 def get_json_type(obj):
 


### PR DESCRIPTION
Fixed a Python 3 compatibility issue according to [Cheat Sheet: Writing Python 2-3 compatible code](http://python-future.org/compatible_idioms.html#reduce).
